### PR TITLE
Add redirect to avoid double content by crawling the site

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source "http://rubygems.org"
 
 gem 'jekyll-sitemap'
+gem 'jekyll-redirect-from'

--- a/_config.yml
+++ b/_config.yml
@@ -138,6 +138,7 @@ footer-imprint-url: impressum
 #####################################
 gems:
   - jekyll-sitemap
+  - jekyll-redirect-from
 
 sass:
   sass_dir: _scss

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8" />
 <title>{{ page.title | strip_html }}</title>
 <meta name="viewport" content="width=device-width, initial-scale=1" />
+<link rel="canonical" href="http://wien.coderdojo.net"/>
 <link rel="shortcut icon" href="{{ site.baseurl }}/images/logos/favicon.png" title="Favicon" />
 <link rel="apple-touch-icon" sizes="180x180" href="{{ site.baseurl }}/images/logos/apple-touch-icon.png">
 <link rel="icon" type="image/png" href="{{ site.baseurl }}/images/logos/favicon-32x32.png" sizes="32x32">

--- a/imprint.html
+++ b/imprint.html
@@ -2,6 +2,7 @@
 layout: default
 title: CoderDojo Wien - Impressum
 permalink: /impressum/
+redirect_to: "http://wien.coderdojo.net/impressum"
 ---
 
 {% include sections/imprint.html %}

--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 layout: default
 title: CoderDojo Wien
 permalink: /
+redirect_to: "http://wien.coderdojo.net"
 ---
 
 {% include sections/about.html %}


### PR DESCRIPTION
Add redirect to avoid double content by crawling the site. See http://stackoverflow.com/questions/9276817/301-redirect-for-site-hosted-at-github and https://github.com/jekyll/jekyll-redirect-from#redirect-to for more details.