### PR TITLE
Fix relative link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -131,7 +131,7 @@ footer-copyright-text: CoderDojo Wien
 footer-copyright-url:
 footer-copyright-year: 2017
 footer-imprint-text: Impressum und Datenschutz
-footer-imprint-url: impressum
+footer-imprint-url: /impressum
 
 #####################################
 ############# Components ############


### PR DESCRIPTION
@akalcik Bitte sieh dir das an, ich habe bemerkt dass der Impressum Url nicht immer passt und ich denke es lag daran dass er nicht absolut sondern relativ zur aktuellen Seite war.